### PR TITLE
Fix for dx-daostack migrations

### DIFF
--- a/contracts/EtherToken.sol
+++ b/contracts/EtherToken.sol
@@ -4,7 +4,7 @@ import "./GnosisStandardToken.sol";
 /// @title Token contract - Token exchanging Ether 1:1
 /// @author Stefan George - <stefan@gnosis.pm>
 contract EtherToken is GnosisStandardToken {
-    using Math for *;
+    using GnosisMath for *;
 
     /*
      *  Events

--- a/contracts/GnosisStandardToken.sol
+++ b/contracts/GnosisStandardToken.sol
@@ -20,7 +20,7 @@ contract StandardTokenData {
  */
 /// @title Standard token contract with overflow protection
 contract GnosisStandardToken is Token, StandardTokenData {
-    using Math for *;
+    using GnosisMath for *;
 
     /*
      *  Public functions

--- a/contracts/Math.sol
+++ b/contracts/Math.sol
@@ -3,7 +3,7 @@ pragma solidity ^0.5.2;
 /// @title Math library - Allows calculation of logarithmic and exponential functions
 /// @author Alan Lu - <alan.lu@gnosis.pm>
 /// @author Stefan George - <stefan@gnosis.pm>
-library Math {
+library GnosisMath {
     /*
      *  Constants
      */

--- a/src/migrations-truffle-4/2_deploy_math.js
+++ b/src/migrations-truffle-4/2_deploy_math.js
@@ -1,5 +1,5 @@
 async function migrate ({ artifacts, deployer }) {
-  const Math = artifacts.require('Math')
+  const Math = artifacts.require('GnosisMath')
   return deployer.deploy(Math)
 }
 

--- a/src/migrations-truffle-4/3_deploy_WETH.js
+++ b/src/migrations-truffle-4/3_deploy_WETH.js
@@ -1,5 +1,5 @@
 async function migrate ({ artifacts, deployer, network }) {
-  const Math = artifacts.require('Math')
+  const Math = artifacts.require('GnosisMath')
   const EtherToken = artifacts.require('EtherToken')
 
   function getWethAddress () {

--- a/src/migrations-truffle-5/2_deploy_math.js
+++ b/src/migrations-truffle-5/2_deploy_math.js
@@ -1,5 +1,5 @@
 async function migrate ({ artifacts, deployer }) {
-  const Math = artifacts.require('Math')
+  const Math = artifacts.require('GnosisMath')
   return deployer.deploy(Math)
 }
 

--- a/src/migrations-truffle-5/3_deploy_WETH.js
+++ b/src/migrations-truffle-5/3_deploy_WETH.js
@@ -1,5 +1,5 @@
 async function migrate ({ artifacts, deployer, network }) {
-  const Math = artifacts.require('Math')
+  const Math = artifacts.require('GnosisMath')
   const EtherToken = artifacts.require('EtherToken')
 
   const wethAddress = _getWethAddress()


### PR DESCRIPTION
Renames Math library to avoid name collisions

Required for [dx-daostack#41](https://github.com/gnosis/dx-daostack/pull/41)