### PR TITLE
Fix check for WETH address

### DIFF
--- a/src/migrations-truffle-5/3_deploy_WETH.js
+++ b/src/migrations-truffle-5/3_deploy_WETH.js
@@ -2,7 +2,7 @@ async function migrate ({ artifacts, deployer, network }) {
   const Math = artifacts.require('GnosisMath')
   const EtherToken = artifacts.require('EtherToken')
 
-  const wethAddress = _getWethAddress()
+  const wethAddress = _getWethAddress(EtherToken)
   if (!wethAddress) {
     console.log(`Deploying WETH contract, because the network "${network}" doesn't have any WETH address configured`)
     // deploy EtherToken (WETH)


### PR DESCRIPTION
Deploy_WETH migration always deploys new WETH when it's supposed to check for an already existing one (Beware of wild `try..catch`)
Screws up plenty of migrations where first WETH is deployed, then its address is used somewhere, then a new WETH is deployed and used somewhere else. Such as dx-mgn-pool migrations

