### PR TITLE
Migration improvements

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@gnosis.pm/util-contracts",
-  "version": "2.1.0",
+  "version": "2.0.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gnosis.pm/util-contracts",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "description": "Utility contracts for Gnosis",
   "main": "index.js",
   "scripts": {

--- a/src/util/truffleConfig.js
+++ b/src/util/truffleConfig.js
@@ -87,8 +87,8 @@ function truffleConfig({
       host: "localhost",
       network_id: "*",
       port: 8555,         // <-- If you change this, also set the port option in .solcover.js.
-      gas,
-      gasPrice
+      gas: 0xfffffffffff, // <-- Use this high gas value
+      gasPrice: 0x01      // <-- Use this low gas price
     }
   }
 


### PR DESCRIPTION

- sets default values for the coverage network, as coverage needs for some reason more gas than usual deployment. (If I don't do it, coverage tool will fail)

---
published npm version 2.0.3