### PR TITLE
check if network key exists

### DIFF
--- a/src/util/networkUtils.js
+++ b/src/util/networkUtils.js
@@ -8,6 +8,7 @@ async function getNetworkInfo (buildPath) {
   return contracts
     // Take just the contracts with network information
     .filter(contract => {
+      if (!contract.networks) return false
       const networkIds = Object.keys(contract.networks)
       return networkIds.length > 0
     })


### PR DESCRIPTION
ran into this problem while using buidler to compile contracts. They don't include network in the artifact by default so this line throws. I've opened an issue on their repo to follow truffle's artifacts format by including the network key. Couldn't hurt to check for the key here anyway...

https://github.com/nomiclabs/buidler/issues/386