### PR TITLE
Exclude event data from networks.json

### DIFF
--- a/src/util/networkUtils.js
+++ b/src/util/networkUtils.js
@@ -46,6 +46,10 @@ function writeNetworksJson (networkInfo, networkFilePath) {
 
 function toNetworkObject (networkInfo) {
   return networkInfo.reduce((acc, contract) => {
+    // Pruning unnecessary event data from network info
+    for (let networkId of Object.keys(contract.networks)) {
+      delete contract.networks[networkId]['events']
+    }
     acc[contract.name] = contract.networks
     return acc
   }, {})

--- a/src/util/networkUtils.js
+++ b/src/util/networkUtils.js
@@ -47,7 +47,7 @@ function writeNetworksJson (networkInfo, networkFilePath) {
 function toNetworkObject (networkInfo) {
   return networkInfo.reduce((acc, contract) => {
     // Pruning unnecessary event data from network info
-    for (let networkId of Object.keys(contract.networks)) {
+    for (const networkId of Object.keys(contract.networks)) {
       delete contract.networks[networkId]['events']
     }
     acc[contract.name] = contract.networks


### PR DESCRIPTION
The `networks.json` file is generally used to easily access the addresses of existing deployed smart contract for a truffle project. However, since this networks file naively parses the contract abi, it comes along with a lot of additional (unnecessary) clutter such as event data. Such clutter, makes the intended use case for the extracted networks file somewhat unreadable without collapsing several lines of text.

This change simply removes the event data immediately before the file is written.