### PR TITLE
[StorageReading] Base contract that exposes contract storage for external reading

### DIFF
--- a/contracts/StorageAccessible.sol
+++ b/contracts/StorageAccessible.sol
@@ -1,0 +1,26 @@
+pragma solidity ^0.5.2;
+
+
+/// @title StorageAccessible - generic base contract that allows callers to access all internal storage.
+contract StorageAccessible {
+    /**
+     * @dev Reads `length` bytes of storage in the currents contract\\
+     * @param offset - the offset in the current contract's storage in words to start reading from
+     * @param length - the number of words (32 bytes) of data to read
+     * @return the bytes that were read.
+     */
+    function getStorageAt(uint256 offset, uint256 length)
+        public
+        view
+        returns (bytes memory)
+    {
+        bytes memory result = new bytes(length * 32);
+        for (uint256 index = 0; index < length; index++) {
+            assembly {
+                let word := sload(add(offset, index))
+                mstore(add(add(result, 0x20), mul(index, 0x20)), word)
+            }
+        }
+        return result;
+    }
+}

--- a/contracts/StorageAccessible.sol
+++ b/contracts/StorageAccessible.sol
@@ -4,7 +4,7 @@ pragma solidity ^0.5.2;
 /// @title StorageAccessible - generic base contract that allows callers to access all internal storage.
 contract StorageAccessible {
     /**
-     * @dev Reads `length` bytes of storage in the currents contract\\
+     * @dev Reads `length` bytes of storage in the currents contract
      * @param offset - the offset in the current contract's storage in words to start reading from
      * @param length - the number of words (32 bytes) of data to read
      * @return the bytes that were read.

--- a/contracts/test/StorageAccessibleWrapper.sol
+++ b/contracts/test/StorageAccessibleWrapper.sol
@@ -8,12 +8,19 @@ contract StorageAccessibleWrapper is StorageAccessible {
         uint256 bar;
     }
 
-    uint256 foo; // slot 0
-    uint128 bar; // slot 1
-    uint64 bam; // slot 1
-    uint256[] baz; // slot 2
-    mapping(uint256 => uint256) qux; // slot 3
-    FooBar foobar; // slot 4 & 5
+    uint8 public constant SLOT_FOO = 0;
+    uint8 public constant SLOT_BAR = 1;
+    uint8 public constant SLOT_BAM = 1;
+    uint8 public constant SLOT_BAZ = 2;
+    uint8 public constant SLOT_QUX = 3;
+    uint8 public constant SLOT_FOOBAR = 4;
+
+    uint256 foo;
+    uint128 bar;
+    uint64 bam;
+    uint256[] baz;
+    mapping(uint256 => uint256) qux;
+    FooBar foobar;
 
     constructor() public {}
 

--- a/contracts/test/StorageAccessibleWrapper.sol
+++ b/contracts/test/StorageAccessibleWrapper.sol
@@ -8,17 +8,36 @@ contract StorageAccessibleWrapper is StorageAccessible {
         uint256 bar;
     }
 
-    uint256 foo = 42; // slot 0
-    uint128 bar = 7; // slot 1
-    uint64 bam = 13; // slot 1
+    uint256 foo; // slot 0
+    uint128 bar; // slot 1
+    uint64 bam; // slot 1
     uint256[] baz; // slot 2
     mapping(uint256 => uint256) qux; // slot 3
     FooBar foobar; // slot 4 & 5
 
-    constructor() public {
-        baz.push(1);
-        baz.push(2);
-        qux[42] = 69;
-        foobar = FooBar({foo: 19, bar: 21});
+    constructor() public {}
+
+    function setFoo(uint256 foo_) public {
+        foo = foo_;
+    }
+
+    function setBar(uint128 bar_) public {
+        bar = bar_;
+    }
+
+    function setBam(uint64 bam_) public {
+        bam = bam_;
+    }
+
+    function setBaz(uint256[] memory baz_) public {
+        baz = baz_;
+    }
+
+    function setQuxKeyValue(uint256 key, uint256 value) public {
+        qux[key] = value;
+    }
+
+    function setFoobar(uint256 foo_, uint256 bar_) public {
+        foobar = FooBar({foo: foo_, bar: bar_});
     }
 }

--- a/contracts/test/StorageAccessibleWrapper.sol
+++ b/contracts/test/StorageAccessibleWrapper.sol
@@ -1,0 +1,24 @@
+pragma solidity ^0.5.2;
+import "../StorageAccessible.sol";
+
+
+contract StorageAccessibleWrapper is StorageAccessible {
+    struct FooBar {
+        uint256 foo;
+        uint256 bar;
+    }
+
+    uint256 foo = 42; // slot 0
+    uint128 bar = 7; // slot 1
+    uint64 bam = 13; // slot 1
+    uint256[] baz; // slot 2
+    mapping(uint256 => uint256) qux; // slot 3
+    FooBar foobar; // slot 4 & 5
+
+    constructor() public {
+        baz.push(1);
+        baz.push(2);
+        qux[42] = 69;
+        foobar = FooBar({foo: 19, bar: 21});
+    }
+}

--- a/test/storage_accessible.js
+++ b/test/storage_accessible.js
@@ -1,0 +1,53 @@
+const StorageAccessibleWrapper = artifacts.require('StorageAccessibleWrapper')
+
+contract('StorageAccessible', () => {
+  const fromHex = string => parseInt(string, 16)
+  const keccak = numbers => web3.utils.soliditySha3(
+    ...numbers.map(v => ({ type: 'uint256', value: v }))
+  )
+
+  it('can read statically sized words', async () => {
+    const instance = await StorageAccessibleWrapper.new()
+
+    // uint256 foo == 42
+    assert.equal(42, await instance.getStorageAt(0, 1))
+  })
+  it('can read fields that are packed into single storage slot', async () => {
+    const instance = await StorageAccessibleWrapper.new()
+    const data = await instance.getStorageAt(1, 1)
+
+    // uint128 bar == 7
+    assert.equal(7, fromHex(data.slice(34, 66)))
+
+    // uint64 bam == 13
+    assert.equal(13, fromHex(data.slice(18, 34)))
+  })
+  it('can read arrays in one go', async () => {
+    const instance = await StorageAccessibleWrapper.new()
+    const length = await instance.getStorageAt(2, 1)
+
+    // baz.len(2) == 2
+    assert.equal(fromHex(length), 2)
+
+    const data = await instance.getStorageAt(keccak([2]), length)
+
+    // baz[0] == 1
+    assert.equal(1, fromHex(data.slice(2, 66)))
+    // baz[1] == 2
+    assert.equal(2, fromHex(data.slice(66, 130)))
+  })
+  it('can read mappings', async () => {
+    const instance = await StorageAccessibleWrapper.new()
+    // qux[42] == 69
+    assert.equal(69, await instance.getStorageAt(keccak([42, 3]), 1))
+  })
+
+  it('can read structs', async () => {
+    const instance = await StorageAccessibleWrapper.new()
+
+    // FooBar foobar = FooBar({foo: 19, bar: 21});
+    const packed = await instance.getStorageAt(4, 10)
+    assert.equal(19, fromHex(packed.slice(2, 66)))
+    assert.equal(21, fromHex(packed.slice(66, 130)))
+  })
+})

--- a/test/storage_accessible.js
+++ b/test/storage_accessible.js
@@ -8,44 +8,41 @@ contract('StorageAccessible', () => {
 
   it('can read statically sized words', async () => {
     const instance = await StorageAccessibleWrapper.new()
+    await instance.setFoo(42)
 
-    // uint256 foo == 42
     assert.equal(42, await instance.getStorageAt(0, 1))
   })
   it('can read fields that are packed into single storage slot', async () => {
     const instance = await StorageAccessibleWrapper.new()
+    await instance.setBar(7)
+    await instance.setBam(13)
+
     const data = await instance.getStorageAt(1, 1)
 
-    // uint128 bar == 7
     assert.equal(7, fromHex(data.slice(34, 66)))
-
-    // uint64 bam == 13
     assert.equal(13, fromHex(data.slice(18, 34)))
   })
   it('can read arrays in one go', async () => {
     const instance = await StorageAccessibleWrapper.new()
-    const length = await instance.getStorageAt(2, 1)
+    await instance.setBaz([1, 2])
 
-    // baz.len(2) == 2
+    const length = await instance.getStorageAt(2, 1)
     assert.equal(fromHex(length), 2)
 
     const data = await instance.getStorageAt(keccak([2]), length)
-
-    // baz[0] == 1
     assert.equal(1, fromHex(data.slice(2, 66)))
-    // baz[1] == 2
     assert.equal(2, fromHex(data.slice(66, 130)))
   })
   it('can read mappings', async () => {
     const instance = await StorageAccessibleWrapper.new()
-    // qux[42] == 69
+    await instance.setQuxKeyValue(42, 69)
     assert.equal(69, await instance.getStorageAt(keccak([42, 3]), 1))
   })
 
   it('can read structs', async () => {
     const instance = await StorageAccessibleWrapper.new()
+    await instance.setFoobar(19, 21)
 
-    // FooBar foobar = FooBar({foo: 19, bar: 21});
     const packed = await instance.getStorageAt(4, 10)
     assert.equal(19, fromHex(packed.slice(2, 66)))
     assert.equal(21, fromHex(packed.slice(66, 130)))

--- a/test/storage_accessible.js
+++ b/test/storage_accessible.js
@@ -10,40 +10,41 @@ contract('StorageAccessible', () => {
     const instance = await StorageAccessibleWrapper.new()
     await instance.setFoo(42)
 
-    assert.equal(42, await instance.getStorageAt(0, 1))
+    assert.equal(42, await instance.getStorageAt(await instance.SLOT_FOO(), 1))
   })
   it('can read fields that are packed into single storage slot', async () => {
     const instance = await StorageAccessibleWrapper.new()
     await instance.setBar(7)
     await instance.setBam(13)
 
-    const data = await instance.getStorageAt(1, 1)
+    const data = await instance.getStorageAt(await instance.SLOT_BAR(), 1)
 
     assert.equal(7, fromHex(data.slice(34, 66)))
     assert.equal(13, fromHex(data.slice(18, 34)))
   })
   it('can read arrays in one go', async () => {
     const instance = await StorageAccessibleWrapper.new()
+    const slot = await instance.SLOT_BAZ()
     await instance.setBaz([1, 2])
 
-    const length = await instance.getStorageAt(2, 1)
+    const length = await instance.getStorageAt(slot, 1)
     assert.equal(fromHex(length), 2)
 
-    const data = await instance.getStorageAt(keccak([2]), length)
+    const data = await instance.getStorageAt(keccak([slot]), length)
     assert.equal(1, fromHex(data.slice(2, 66)))
     assert.equal(2, fromHex(data.slice(66, 130)))
   })
   it('can read mappings', async () => {
     const instance = await StorageAccessibleWrapper.new()
     await instance.setQuxKeyValue(42, 69)
-    assert.equal(69, await instance.getStorageAt(keccak([42, 3]), 1))
+    assert.equal(69, await instance.getStorageAt(keccak([42, await instance.SLOT_QUX()]), 1))
   })
 
   it('can read structs', async () => {
     const instance = await StorageAccessibleWrapper.new()
     await instance.setFoobar(19, 21)
 
-    const packed = await instance.getStorageAt(4, 10)
+    const packed = await instance.getStorageAt(await instance.SLOT_FOOBAR(), 10)
     assert.equal(19, fromHex(packed.slice(2, 66)))
     assert.equal(21, fromHex(packed.slice(66, 130)))
   })


### PR DESCRIPTION
This PR introduces a new utility base contract which allows other smart contracts and offchain infrastructure to efficiently read internal storage (by inheriting from `StorageAccessible`).

This is achieved by exposing a single `getStorageAt` method (similar to [the web3 method](https://web3js.readthedocs.io/en/v1.2.0/web3-eth.html?highlight=getStorageAt#getstorageat)), which takes as an argument the storage slot that should be read.

There are 2 advantages of this method over using the web3 one.

1. It also allows reading multiple words at once, making it more efficient to read larger structs or arrays of data with one roundtrip
2. It can be invoked by other smart contracts (e.g. contracts integrating with Gnosis Protocol that want to read the private balance variable of a user)

Given that all storage is already readable to the public via consecutive web3 calls there is no security concern of exposing it more conveniently.

One could argue that smart contracts should not have any private fields in the first place. However, even with only public fields some nested information (such as the elements in an array on a top level struct) are not automatically exposed (and assuming to foresee all data fetching requirements at deployment time has proven flawed).

In a follow up PR, we can also expose a more convenient way of reading internal storage, which would expose a method to do a "static delegate call" to another contract. That other contract can be controlled by the caller and use arbitrary solidity code to act on the local storage of the original contract.

This will be similar to the [state override feature in geth](https://geth.ethereum.org/docs/rpc/ns-eth#3-object---state-override-set) but make it client agnostic and available to other smart contracts.

However, the functionality here is a first step and seems valuable in itself since it doesn't require deploying a "viewer" smart contract and can thus prove cheaper for small data fetching use cases.

### Test Plan

I added unit tests that use the `getStorageAt` method to query data from a wrapper smart contract that inherits from `StorageAccessible`.

`yarn truffle test`