### PR TITLE
[StorageReading] Invoke external viewer contract via static delegatecall

### DIFF
--- a/contracts/StorageAccessible.sol
+++ b/contracts/StorageAccessible.sol
@@ -69,6 +69,7 @@ contract StorageAccessible {
     }
 
     function isRevert(bytes memory result) public pure returns (bool) {
+        // Check if result starts with the method selector "Error(string)"
         return
             result.length > 4 &&
             result[0] == 0x08 &&

--- a/contracts/StorageAccessible.sol
+++ b/contracts/StorageAccessible.sol
@@ -30,12 +30,12 @@ contract StorageAccessible {
      * @param targetContract Address of the contract containing the code to execute.
      * @param calldataPayload Calldata that should be sent to the target contract (encoded method name and arguments).
      */
-    function executeStaticDelegatecall(
+    function simulateDelegatecall(
         address targetContract,
         bytes memory calldataPayload
     ) public returns (bytes memory) {
         bytes memory innerCall = abi.encodeWithSignature(
-            "executeStaticDelegatecallInternal(address,bytes)",
+            "simulateDelegatecallInternal(address,bytes)",
             targetContract,
             calldataPayload
         );
@@ -49,7 +49,7 @@ contract StorageAccessible {
      * @param targetContract Address of the contract containing the code to execute.
      * @param calldataPayload Calldata that should be sent to the target contract (encoded method name and arguments).
      */
-    function executeStaticDelegatecallInternal(
+    function simulateDelegatecallInternal(
         address targetContract,
         bytes memory calldataPayload
     ) public returns (bytes memory) {

--- a/contracts/StorageAccessible.sol
+++ b/contracts/StorageAccessible.sol
@@ -54,7 +54,8 @@ contract StorageAccessible {
 
     /**
      * @dev Performs a delegetecall on a targetContract in the context of self.
-     * Internally reverts execution to avoid side effects (making it static). Returns encoded result as revert message.
+     * Internally reverts execution to avoid side effects (making it static). Returns encoded result as revert message
+     * concatenated with the success flag of the inner call as a last byte.
      * @param targetContract Address of the contract containing the code to execute.
      * @param calldataPayload Calldata that should be sent to the target contract (encoded method name and arguments).
      */

--- a/contracts/StorageAccessible.sol
+++ b/contracts/StorageAccessible.sol
@@ -3,6 +3,10 @@ pragma solidity ^0.5.2;
 
 /// @title StorageAccessible - generic base contract that allows callers to access all internal storage.
 contract StorageAccessible {
+    bytes4 public constant SIMULATE_DELEGATECALL_INTERNAL_SELECTOR = bytes4(
+        keccak256("simulateDelegatecallInternal(address,bytes)")
+    );
+
     /**
      * @dev Reads `length` bytes of storage in the currents contract
      * @param offset - the offset in the current contract's storage in words to start reading from
@@ -34,8 +38,8 @@ contract StorageAccessible {
         address targetContract,
         bytes memory calldataPayload
     ) public returns (bytes memory) {
-        bytes memory innerCall = abi.encodeWithSignature(
-            "simulateDelegatecallInternal(address,bytes)",
+        bytes memory innerCall = abi.encodeWithSelector(
+            SIMULATE_DELEGATECALL_INTERNAL_SELECTOR,
             targetContract,
             calldataPayload
         );

--- a/contracts/test/StorageAccessibleWrapper.sol
+++ b/contracts/test/StorageAccessibleWrapper.sol
@@ -62,9 +62,8 @@ contract ExternalStorageReader {
         return foo;
     }
 
-    function replaceFoo(uint256 foo_) public returns (uint256) {
-        uint256 tmp = foo;
+    function setAndGetFoo(uint256 foo_) public returns (uint256) {
         foo = foo_;
-        return tmp;
+        return foo;
     }
 }

--- a/contracts/test/StorageAccessibleWrapper.sol
+++ b/contracts/test/StorageAccessibleWrapper.sol
@@ -1,7 +1,6 @@
 pragma solidity ^0.5.2;
 import "../StorageAccessible.sol";
 
-
 contract StorageAccessibleWrapper is StorageAccessible {
     struct FooBar {
         uint256 foo;
@@ -49,7 +48,6 @@ contract StorageAccessibleWrapper is StorageAccessible {
     }
 }
 
-
 /**
  * Defines reader methods on StorageAccessibleWrapper that can be later executed
  * in the context of a previously deployed instance
@@ -69,5 +67,16 @@ contract ExternalStorageReader {
 
     function doRevert() public pure {
         revert("Foo");
+    }
+
+    function invokeDoRevertViaStorageAccessible(StorageAccessible target)
+        public
+        returns (bytes memory)
+    {
+        return
+            target.simulateDelegatecall(
+                address(this),
+                abi.encodeWithSignature("doRevert()")
+            );
     }
 }

--- a/contracts/test/StorageAccessibleWrapper.sol
+++ b/contracts/test/StorageAccessibleWrapper.sol
@@ -66,4 +66,8 @@ contract ExternalStorageReader {
         foo = foo_;
         return foo;
     }
+
+    function doRevert() public pure {
+        revert("Foo");
+    }
 }

--- a/contracts/test/StorageAccessibleWrapper.sol
+++ b/contracts/test/StorageAccessibleWrapper.sol
@@ -66,7 +66,7 @@ contract ExternalStorageReader {
     }
 
     function doRevert() public pure {
-        revert("Foo");
+        revert();
     }
 
     function invokeDoRevertViaStorageAccessible(StorageAccessible target)

--- a/contracts/test/StorageAccessibleWrapper.sol
+++ b/contracts/test/StorageAccessibleWrapper.sol
@@ -71,12 +71,10 @@ contract ExternalStorageReader {
 
     function invokeDoRevertViaStorageAccessible(StorageAccessible target)
         public
-        returns (bytes memory)
     {
-        return
-            target.simulateDelegatecall(
-                address(this),
-                abi.encodeWithSignature("doRevert()")
-            );
+        target.simulateDelegatecall(
+            address(this),
+            abi.encodeWithSignature("doRevert()")
+        );
     }
 }

--- a/contracts/test/StorageAccessibleWrapper.sol
+++ b/contracts/test/StorageAccessibleWrapper.sol
@@ -48,3 +48,23 @@ contract StorageAccessibleWrapper is StorageAccessible {
         foobar = FooBar({foo: foo_, bar: bar_});
     }
 }
+
+
+/**
+ * Defines reader methods on StorageAccessibleWrapper that can be later executed
+ * in the context of a previously deployed instance
+ */
+contract ExternalStorageReader {
+    // Needs same storage layout as the contract it is reading from
+    uint256 foo;
+
+    function getFoo() public view returns (uint256) {
+        return foo;
+    }
+
+    function replaceFoo(uint256 foo_) public returns (uint256) {
+        uint256 tmp = foo;
+        foo = foo_;
+        return tmp;
+    }
+}

--- a/test/storage_accessible.js
+++ b/test/storage_accessible.js
@@ -87,7 +87,7 @@ contract('StorageAccessible', () => {
 
       const reader = await ExternalStorageReader.new()
       const doRevertCall = reader.contract.methods.doRevert().encodeABI()
-      truffleAssert.reverts(instance.simulateDelegatecall.call(reader.address), doRevertCall)
+      truffleAssert.reverts(instance.simulateDelegatecall.call(reader.address, doRevertCall))
     })
   })
 })

--- a/test/storage_accessible.js
+++ b/test/storage_accessible.js
@@ -89,5 +89,12 @@ contract('StorageAccessible', () => {
       const doRevertCall = reader.contract.methods.doRevert().encodeABI()
       truffleAssert.reverts(instance.simulateDelegatecall.call(reader.address, doRevertCall))
     })
+
+    it('allows detection of reverts when invoked from other smart contract', async () => {
+      const instance = await StorageAccessibleWrapper.new()
+
+      const reader = await ExternalStorageReader.new()
+      truffleAssert.reverts(reader.invokeDoRevertViaStorageAccessible(instance.address))
+    })
   })
 })

--- a/test/storage_accessible.js
+++ b/test/storage_accessible.js
@@ -52,7 +52,7 @@ contract('StorageAccessible', () => {
     })
   })
 
-  describe.only('executeStaticDelegatecall', async () => {
+  describe.only('simulateDelegatecall', async () => {
     it('can invoke a function in the context of a previously deployed contract', async () => {
       const instance = await StorageAccessibleWrapper.new()
       await instance.setFoo(42)
@@ -60,7 +60,7 @@ contract('StorageAccessible', () => {
       // Deploy and use reader contract to access foo
       const reader = await ExternalStorageReader.new()
       const getFooCall = reader.contract.methods.getFoo().encodeABI()
-      const result = await instance.executeStaticDelegatecall.call(reader.address, getFooCall)
+      const result = await instance.simulateDelegatecall.call(reader.address, getFooCall)
       assert.equal(42, fromHex(result))
     })
 
@@ -71,12 +71,12 @@ contract('StorageAccessible', () => {
       // Deploy and use reader contract to get and replace foo
       const reader = await ExternalStorageReader.new()
       const replaceFooCall = reader.contract.methods.replaceFoo(69).encodeABI()
-      let result = await instance.executeStaticDelegatecall.call(reader.address, replaceFooCall)
+      let result = await instance.simulateDelegatecall.call(reader.address, replaceFooCall)
       assert.equal(42, fromHex(result))
 
       // Make sure foo is not actually changed
       const getFooCall = reader.contract.methods.getFoo().encodeABI()
-      result = await instance.executeStaticDelegatecall.call(reader.address, getFooCall)
+      result = await instance.simulateDelegatecall.call(reader.address, getFooCall)
       assert.equal(42, fromHex(result))
     })
   })

--- a/test/storage_accessible.js
+++ b/test/storage_accessible.js
@@ -1,4 +1,5 @@
 const StorageAccessibleWrapper = artifacts.require('StorageAccessibleWrapper')
+const ExternalStorageReader = artifacts.require('ExternalStorageReader')
 
 contract('StorageAccessible', () => {
   const fromHex = string => parseInt(string, 16)
@@ -6,46 +7,77 @@ contract('StorageAccessible', () => {
     ...numbers.map(v => ({ type: 'uint256', value: v }))
   )
 
-  it('can read statically sized words', async () => {
-    const instance = await StorageAccessibleWrapper.new()
-    await instance.setFoo(42)
+  describe('getStorageAt', async () => {
+    it('can read statically sized words', async () => {
+      const instance = await StorageAccessibleWrapper.new()
+      await instance.setFoo(42)
 
-    assert.equal(42, await instance.getStorageAt(await instance.SLOT_FOO(), 1))
+      assert.equal(42, await instance.getStorageAt(await instance.SLOT_FOO(), 1))
+    })
+    it('can read fields that are packed into single storage slot', async () => {
+      const instance = await StorageAccessibleWrapper.new()
+      await instance.setBar(7)
+      await instance.setBam(13)
+
+      const data = await instance.getStorageAt(await instance.SLOT_BAR(), 1)
+
+      assert.equal(7, fromHex(data.slice(34, 66)))
+      assert.equal(13, fromHex(data.slice(18, 34)))
+    })
+    it('can read arrays in one go', async () => {
+      const instance = await StorageAccessibleWrapper.new()
+      const slot = await instance.SLOT_BAZ()
+      await instance.setBaz([1, 2])
+
+      const length = await instance.getStorageAt(slot, 1)
+      assert.equal(fromHex(length), 2)
+
+      const data = await instance.getStorageAt(keccak([slot]), length)
+      assert.equal(1, fromHex(data.slice(2, 66)))
+      assert.equal(2, fromHex(data.slice(66, 130)))
+    })
+    it('can read mappings', async () => {
+      const instance = await StorageAccessibleWrapper.new()
+      await instance.setQuxKeyValue(42, 69)
+      assert.equal(69, await instance.getStorageAt(keccak([42, await instance.SLOT_QUX()]), 1))
+    })
+
+    it('can read structs', async () => {
+      const instance = await StorageAccessibleWrapper.new()
+      await instance.setFoobar(19, 21)
+
+      const packed = await instance.getStorageAt(await instance.SLOT_FOOBAR(), 10)
+      assert.equal(19, fromHex(packed.slice(2, 66)))
+      assert.equal(21, fromHex(packed.slice(66, 130)))
+    })
   })
-  it('can read fields that are packed into single storage slot', async () => {
-    const instance = await StorageAccessibleWrapper.new()
-    await instance.setBar(7)
-    await instance.setBam(13)
 
-    const data = await instance.getStorageAt(await instance.SLOT_BAR(), 1)
+  describe.only('executeStaticDelegatecall', async () => {
+    it('can invoke a function in the context of a previously deployed contract', async () => {
+      const instance = await StorageAccessibleWrapper.new()
+      await instance.setFoo(42)
 
-    assert.equal(7, fromHex(data.slice(34, 66)))
-    assert.equal(13, fromHex(data.slice(18, 34)))
-  })
-  it('can read arrays in one go', async () => {
-    const instance = await StorageAccessibleWrapper.new()
-    const slot = await instance.SLOT_BAZ()
-    await instance.setBaz([1, 2])
+      // Deploy and use reader contract to access foo
+      const reader = await ExternalStorageReader.new()
+      const getFooCall = reader.contract.methods.getFoo().encodeABI()
+      const result = await instance.executeStaticDelegatecall.call(reader.address, getFooCall)
+      assert.equal(42, fromHex(result))
+    })
 
-    const length = await instance.getStorageAt(slot, 1)
-    assert.equal(fromHex(length), 2)
+    it('can simulate a function with side effects (without executing)', async () => {
+      const instance = await StorageAccessibleWrapper.new()
+      await instance.setFoo(42)
 
-    const data = await instance.getStorageAt(keccak([slot]), length)
-    assert.equal(1, fromHex(data.slice(2, 66)))
-    assert.equal(2, fromHex(data.slice(66, 130)))
-  })
-  it('can read mappings', async () => {
-    const instance = await StorageAccessibleWrapper.new()
-    await instance.setQuxKeyValue(42, 69)
-    assert.equal(69, await instance.getStorageAt(keccak([42, await instance.SLOT_QUX()]), 1))
-  })
+      // Deploy and use reader contract to get and replace foo
+      const reader = await ExternalStorageReader.new()
+      const replaceFooCall = reader.contract.methods.replaceFoo(69).encodeABI()
+      let result = await instance.executeStaticDelegatecall.call(reader.address, replaceFooCall)
+      assert.equal(42, fromHex(result))
 
-  it('can read structs', async () => {
-    const instance = await StorageAccessibleWrapper.new()
-    await instance.setFoobar(19, 21)
-
-    const packed = await instance.getStorageAt(await instance.SLOT_FOOBAR(), 10)
-    assert.equal(19, fromHex(packed.slice(2, 66)))
-    assert.equal(21, fromHex(packed.slice(66, 130)))
+      // Make sure foo is not actually changed
+      const getFooCall = reader.contract.methods.getFoo().encodeABI()
+      result = await instance.executeStaticDelegatecall.call(reader.address, getFooCall)
+      assert.equal(42, fromHex(result))
+    })
   })
 })

--- a/test/storage_accessible.js
+++ b/test/storage_accessible.js
@@ -68,11 +68,11 @@ contract('StorageAccessible', () => {
       const instance = await StorageAccessibleWrapper.new()
       await instance.setFoo(42)
 
-      // Deploy and use reader contract to get and replace foo
+      // Deploy and use reader contract to simulate setting foo
       const reader = await ExternalStorageReader.new()
-      const replaceFooCall = reader.contract.methods.replaceFoo(69).encodeABI()
+      const replaceFooCall = reader.contract.methods.setAndGetFoo(69).encodeABI()
       let result = await instance.simulateDelegatecall.call(reader.address, replaceFooCall)
-      assert.equal(42, fromHex(result))
+      assert.equal(69, fromHex(result))
 
       // Make sure foo is not actually changed
       const getFooCall = reader.contract.methods.getFoo().encodeABI()

--- a/test/storage_accessible.js
+++ b/test/storage_accessible.js
@@ -1,6 +1,8 @@
 const StorageAccessibleWrapper = artifacts.require('StorageAccessibleWrapper')
 const ExternalStorageReader = artifacts.require('ExternalStorageReader')
 
+const truffleAssert = require('truffle-assertions')
+
 contract('StorageAccessible', () => {
   const fromHex = string => parseInt(string, 16)
   const keccak = numbers => web3.utils.soliditySha3(
@@ -78,6 +80,14 @@ contract('StorageAccessible', () => {
       const getFooCall = reader.contract.methods.getFoo().encodeABI()
       result = await instance.simulateDelegatecall.call(reader.address, getFooCall)
       assert.equal(42, fromHex(result))
+    })
+
+    it('can simulate a function that reverts', async () => {
+      const instance = await StorageAccessibleWrapper.new()
+
+      const reader = await ExternalStorageReader.new()
+      const doRevertCall = reader.contract.methods.doRevert().encodeABI()
+      truffleAssert.reverts(instance.simulateDelegatecall.call(reader.address), doRevertCall)
     })
   })
 })

--- a/test/storage_accessible.js
+++ b/test/storage_accessible.js
@@ -52,7 +52,7 @@ contract('StorageAccessible', () => {
     })
   })
 
-  describe.only('simulateDelegatecall', async () => {
+  describe('simulateDelegatecall', async () => {
     it('can invoke a function in the context of a previously deployed contract', async () => {
       const instance = await StorageAccessibleWrapper.new()
       await instance.setFoo(42)


### PR DESCRIPTION
While #30 works great for reading specific one-off storage slots, it is not very convenient in case we want to add more sophisticated view function logic to an already deployed contract (e.g. to [improve gas efficiency for view functions on Gnosis Protocol](https://github.com/gnosis/dex-contracts/issues/641))

This PR allows anyone to deploy a smart contract with the same storage layout as our original (StorageReading subclassed) contract  and implement arbitrary view functions on it. They can then invoke `executeStaticDelegatecall` on the existing contract, which will execute **their code** in **its own context** via a delegatecall (using the state of the original contract). Whatever happens in this call is reverted in the end, making it side-effect-less (static).

The return value is returned as abi-encoded bytes for easier consumption in web3 as well as other smart contracts (encoding as revert message would suffice for the latter).

The cool thing is that we can even invoke methods that are non-view (i.e. have side effects) and thus simulate more complex invocations. All side effects will be reverted, the returned result remains.

This is similar to the [state override feature in geth](https://geth.ethereum.org/docs/rpc/ns-eth#3-object---state-override-set) but make it client agnostic and available to other smart contracts.

Credit goes to @rmeissner who wrote this code [before](https://github.com/gnosis/safe-contracts/blob/v2/contracts/base/StateProvider.sol) (I'm just making it generally accessible here)

### Test Plan

Added unit test to demonstrate how a fixed contract can be amended with reader functionality.