### PR TITLE
[StorageAccessible] invokeStaticDelegatecall

### DIFF
--- a/contracts/StorageAccessible.sol
+++ b/contracts/StorageAccessible.sol
@@ -53,6 +53,30 @@ contract StorageAccessible {
     }
 
     /**
+     * @dev Same as simulateDelegatecall but with view modifier (only uses static context)
+     * @param targetContract Address of the contract containing the code to execute.
+     * @param calldataPayload Calldata that should be sent to the target contract (encoded method name and arguments).
+     */
+    function simulateStaticDelegatecall(
+        address targetContract,
+        bytes memory calldataPayload
+    ) public view returns (bytes memory) {
+        bytes memory innerCall = abi.encodeWithSelector(
+            SIMULATE_DELEGATECALL_INTERNAL_SELECTOR,
+            targetContract,
+            calldataPayload
+        );
+        (, bytes memory response) = address(this).staticcall(innerCall);
+        bool innerSuccess = response[response.length - 1] == 0x01;
+        setLength(response, response.length - 1);
+        if (innerSuccess) {
+            return response;
+        } else {
+            revertWith(response);
+        }
+    }
+
+    /**
      * @dev Performs a delegetecall on a targetContract in the context of self.
      * Internally reverts execution to avoid side effects (making it static). Returns encoded result as revert message
      * concatenated with the success flag of the inner call as a last byte.

--- a/contracts/test/StorageAccessibleWrapper.sol
+++ b/contracts/test/StorageAccessibleWrapper.sol
@@ -77,4 +77,13 @@ contract ExternalStorageReader {
             abi.encodeWithSignature("doRevert()")
         );
     }
+
+    function invokeStaticDelegatecall(StorageAccessible target) public view returns (uint256) {
+        uint result = abi.decode(
+            target.simulateStaticDelegatecall(
+                address(this),
+                abi.encodeWithSignature("getFoo()")
+            ), (uint));
+        return result;
+    }
 }

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
   },
   "homepage": "https://github.com/gnosis/util-contracts#readme",
   "devDependencies": {
+    "@truffle/contract": "^4.1.2",
     "dotenv": "^8.0.0",
     "eslint": "^5.16.0",
     "eslint-config-standard": "^12.0.0",
@@ -47,7 +48,7 @@
     "prettier-plugin-solidity-refactor": "^1.0.0-alpha.12",
     "solc": "0.5.8",
     "truffle": "^5.0.2",
-    "@truffle/contract": "^4.1.2"
+    "truffle-assertions": "^0.9.2"
   },
   "dependencies": {
     "@truffle/hdwallet-provider": "^1.0.42"

--- a/test/storage_accessible.js
+++ b/test/storage_accessible.js
@@ -97,4 +97,16 @@ contract('StorageAccessible', () => {
       truffleAssert.reverts(reader.invokeDoRevertViaStorageAccessible(instance.address))
     })
   })
+
+  describe.only('simulateStaticDelegatecall', () => {
+    it('can be called from a static context', async () => {
+      const instance = await StorageAccessibleWrapper.new()
+      await instance.setFoo(42)
+
+      const reader = await ExternalStorageReader.new()
+      // invokeStaticDelegatecall is marked as view
+      const result = await reader.invokeStaticDelegatecall(instance.address)
+      assert.equal(42, result)
+    })
+  })
 })

--- a/test/storage_accessible.js
+++ b/test/storage_accessible.js
@@ -98,7 +98,7 @@ contract('StorageAccessible', () => {
     })
   })
 
-  describe.only('simulateStaticDelegatecall', () => {
+  describe('simulateStaticDelegatecall', () => {
     it('can be called from a static context', async () => {
       const instance = await StorageAccessibleWrapper.new()
       await instance.setFoo(42)
@@ -107,6 +107,15 @@ contract('StorageAccessible', () => {
       // invokeStaticDelegatecall is marked as view
       const result = await reader.invokeStaticDelegatecall(instance.address)
       assert.equal(42, result)
+    })
+
+    it('cannot simulate state changes', async () => {
+      const instance = await StorageAccessibleWrapper.new()
+      await instance.setFoo(42)
+
+      const reader = await ExternalStorageReader.new()
+      const replaceFooCall = reader.contract.methods.setAndGetFoo(69).encodeABI()
+      truffleAssert.reverts(instance.simulateStaticDelegatecall(reader.address, replaceFooCall))
     })
   })
 })

--- a/yarn.lock
+++ b/yarn.lock
@@ -591,6 +591,11 @@ assert-plus@1.0.0, assert-plus@^1.0.0:
   resolved "https://registry.yarnpkg.com/assert-plus/-/assert-plus-1.0.0.tgz#f12e0f3c5d77b0b1cdd9146942e4e96c1e4dd525"
   integrity sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=
 
+assertion-error@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/assertion-error/-/assertion-error-1.1.0.tgz#e60b6b0e8f301bd97e5375215bda406c85118c0b"
+  integrity sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==
+
 astral-regex@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/astral-regex/-/astral-regex-1.0.0.tgz#6c8c3fb827dd43ee3918f27b82782ab7658a6fd9"
@@ -3272,6 +3277,11 @@ lodash.flatmap@^4.5.0:
   resolved "https://registry.yarnpkg.com/lodash.flatmap/-/lodash.flatmap-4.5.0.tgz#ef8cbf408f6e48268663345305c6acc0b778702e"
   integrity sha1-74y/QI9uSCaGYzRTBcaswLd4cC4=
 
+lodash.isequal@^4.5.0:
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/lodash.isequal/-/lodash.isequal-4.5.0.tgz#415c4478f2bcc30120c22ce10ed3226f7d3e18e0"
+  integrity sha1-QVxEePK8wwEgwizhDtMib30+GOA=
+
 lodash.merge@^4.6.2:
   version "4.6.2"
   resolved "https://registry.yarnpkg.com/lodash.merge/-/lodash.merge-4.6.2.tgz#558aa53b43b661e1925a0afdfa36a9a1085fe57a"
@@ -4896,6 +4906,14 @@ tough-cookie@~2.4.3:
   dependencies:
     psl "^1.1.24"
     punycode "^1.4.1"
+
+truffle-assertions@^0.9.2:
+  version "0.9.2"
+  resolved "https://registry.yarnpkg.com/truffle-assertions/-/truffle-assertions-0.9.2.tgz#0f8360f53ad92b6d8fdb8ceb5dce54c1fc392e23"
+  integrity sha512-9g2RhaxU2F8DeWhqoGQvL/bV8QVoSnQ6PY+ZPvYRP5eF7+/8LExb4mjLx/FeliLTjc3Tv1SABG05Gu5qQ/ErmA==
+  dependencies:
+    assertion-error "^1.1.0"
+    lodash.isequal "^4.5.0"
 
 truffle@^5.0.2:
   version "5.0.2"


### PR DESCRIPTION
Previously when other smartcontracts wanted to invoke `simulateDelegatecall` the callsite could not be a view method (since `simulateDelegatecall` itself isn't a view method). 

While there are good use cases for allowing non static invocations of `simulateDelegatecall` (e.g. when we want to simulate some statechange and then query data), it can be inconvenient (e.g. in js we always have to .call since otherwise this would send a tx.

This PR adds another method on the StorageAccessible contract that wraps the inner call in a `staticCall` thus allowing the callsite to be declared as view.

We need to discuss if the added bytecode is worthwhile this feature or if there are better options.

### Test Plan

Added unittests