### PR TITLE
Implement simulateStaticDelegatecall via interface

### DIFF
--- a/contracts/StorageAccessible.sol
+++ b/contracts/StorageAccessible.sol
@@ -1,7 +1,12 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 pragma solidity ^0.6.0;
 
+/// @title ViewStorageAccessible - Interface on top of StorageAccessible base class to allow simulations from view functions
 interface ViewStorageAccessible {
+    /**
+     * @dev Same as `simulateDelegatecall` on StorageAccessible. Marked as view so that it can be called from external contracts
+     * that want to run simulations for within view functions. Will revert if the invoked simulation attempt to change state.
+     */
     function simulateDelegatecall(
         address targetContract,
         bytes memory calldataPayload

--- a/contracts/StorageAccessible.sol
+++ b/contracts/StorageAccessible.sol
@@ -1,6 +1,13 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 pragma solidity ^0.6.0;
 
+interface ViewStorageAccessible {
+    function simulateDelegatecall(
+        address targetContract,
+        bytes memory calldataPayload
+    ) external view returns (bytes memory);
+}
+
 /// @title StorageAccessible - generic base contract that allows callers to access all internal storage.
 contract StorageAccessible {
     bytes4 public constant SIMULATE_DELEGATECALL_INTERNAL_SELECTOR = bytes4(
@@ -44,30 +51,6 @@ contract StorageAccessible {
             calldataPayload
         );
         (, bytes memory response) = address(this).call(innerCall);
-        bool innerSuccess = response[response.length - 1] == 0x01;
-        setLength(response, response.length - 1);
-        if (innerSuccess) {
-            return response;
-        } else {
-            revertWith(response);
-        }
-    }
-
-    /**
-     * @dev Same as simulateDelegatecall but with view modifier (only uses static context)
-     * @param targetContract Address of the contract containing the code to execute.
-     * @param calldataPayload Calldata that should be sent to the target contract (encoded method name and arguments).
-     */
-    function simulateStaticDelegatecall(
-        address targetContract,
-        bytes memory calldataPayload
-    ) public view returns (bytes memory) {
-        bytes memory innerCall = abi.encodeWithSelector(
-            SIMULATE_DELEGATECALL_INTERNAL_SELECTOR,
-            targetContract,
-            calldataPayload
-        );
-        (, bytes memory response) = address(this).staticcall(innerCall);
         bool innerSuccess = response[response.length - 1] == 0x01;
         setLength(response, response.length - 1);
         if (innerSuccess) {

--- a/contracts/StorageAccessible.sol
+++ b/contracts/StorageAccessible.sol
@@ -5,7 +5,7 @@ pragma solidity ^0.6.0;
 interface ViewStorageAccessible {
     /**
      * @dev Same as `simulateDelegatecall` on StorageAccessible. Marked as view so that it can be called from external contracts
-     * that want to run simulations for within view functions. Will revert if the invoked simulation attempt to change state.
+     * that want to run simulations from within view functions. Will revert if the invoked simulation attempts to change state.
      */
     function simulateDelegatecall(
         address targetContract,

--- a/contracts/test/StorageAccessibleWrapper.sol
+++ b/contracts/test/StorageAccessibleWrapper.sol
@@ -79,12 +79,14 @@ contract ExternalStorageReader {
         );
     }
 
-    function invokeStaticDelegatecall(StorageAccessible target) public view returns (uint256) {
-        uint result = abi.decode(
-            target.simulateStaticDelegatecall(
-                address(this),
-                abi.encodeWithSignature("getFoo()")
-            ), (uint));
+    function invokeStaticDelegatecall(
+        ViewStorageAccessible target,
+        bytes calldata encodedCall
+    ) public view returns (uint256) {
+        uint256 result = abi.decode(
+            target.simulateDelegatecall(address(this), encodedCall),
+            (uint256)
+        );
         return result;
     }
 }

--- a/test/storage_accessible.js
+++ b/test/storage_accessible.js
@@ -104,8 +104,9 @@ contract('StorageAccessible', () => {
       await instance.setFoo(42)
 
       const reader = await ExternalStorageReader.new()
+      const getFooCall = reader.contract.methods.getFoo().encodeABI()
       // invokeStaticDelegatecall is marked as view
-      const result = await reader.invokeStaticDelegatecall(instance.address)
+      const result = await reader.invokeStaticDelegatecall(instance.address, getFooCall)
       assert.equal(42, result)
     })
 
@@ -115,7 +116,7 @@ contract('StorageAccessible', () => {
 
       const reader = await ExternalStorageReader.new()
       const replaceFooCall = reader.contract.methods.setAndGetFoo(69).encodeABI()
-      truffleAssert.reverts(instance.simulateStaticDelegatecall(reader.address, replaceFooCall))
+      truffleAssert.reverts(reader.invokeStaticDelegatecall(reader.address, replaceFooCall))
     })
   })
 })


### PR DESCRIPTION
As per @rmeissner's suggestion in #38. This is a much more elegant way of achieving the same thing (no code duplication). Unfortunately this is an API breaking change and we already published the npm package vor v3.0.0. Maybe we can deprecate this package and republish this without a major version update?

### Test Plan

unit test still passing.