### PR TITLE
Version bump to 3.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gnosis.pm/util-contracts",
-  "version": "3.0.1-solc-7",
+  "version": "3.1.0-solc-7",
   "description": "Utility contracts for Gnosis",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
This PR bumps the version to `3.1.0` for the `solc-7` release branch in order to include the changes to `StorageAccessible` function visibility.

Note that the change has not yet been backported to `master`, and I'm not sure exactly how we want to proceed regarding supporting multiple Solidity versions.

