### PR TITLE
Rename StorageAccessible methods to be more succinct

### DIFF
--- a/contracts/test/StorageAccessibleWrapper.sol
+++ b/contracts/test/StorageAccessibleWrapper.sol
@@ -73,7 +73,7 @@ contract ExternalStorageReader {
     function invokeDoRevertViaStorageAccessible(StorageAccessible target)
         public
     {
-        target.simulateDelegatecall(
+        target.simulate(
             address(this),
             abi.encodeWithSignature("doRevert()")
         );
@@ -84,7 +84,7 @@ contract ExternalStorageReader {
         bytes calldata encodedCall
     ) public view returns (uint256) {
         uint256 result = abi.decode(
-            target.simulateDelegatecall(address(this), encodedCall),
+            target.simulate(address(this), encodedCall),
             (uint256)
         );
         return result;

--- a/test/storage_accessible.ts
+++ b/test/storage_accessible.ts
@@ -68,7 +68,7 @@ describe("StorageAccessible", () => {
     });
   });
 
-  describe("simulateDelegatecall", async () => {
+  describe("simulate", async () => {
     it("can invoke a function in the context of a previously deployed contract", async () => {
       const instance = await StorageAccessibleWrapper.deploy();
       await instance.setFoo(42);
@@ -76,7 +76,7 @@ describe("StorageAccessible", () => {
       // Deploy and use reader contract to access foo
       const reader = await ExternalStorageReader.deploy();
       const getFooCall = reader.interface.encodeFunctionData("getFoo");
-      const result = await instance.callStatic.simulateDelegatecall(reader.address, getFooCall);
+      const result = await instance.callStatic.simulate(reader.address, getFooCall);
       expect(fromHex(result)).to.equal(42);
     });
 
@@ -87,12 +87,12 @@ describe("StorageAccessible", () => {
       // Deploy and use reader contract to simulate setting foo
       const reader = await ExternalStorageReader.deploy();
       const replaceFooCall = reader.interface.encodeFunctionData("setAndGetFoo", [69]);
-      let result = await instance.callStatic.simulateDelegatecall(reader.address, replaceFooCall);
+      let result = await instance.callStatic.simulate(reader.address, replaceFooCall);
       expect(fromHex(result)).to.equal(69);
 
       // Make sure foo is not actually changed
       const getFooCall = reader.interface.encodeFunctionData("getFoo");
-      result = await instance.callStatic.simulateDelegatecall(reader.address, getFooCall);
+      result = await instance.callStatic.simulate(reader.address, getFooCall);
       expect(fromHex(result)).to.equal(42);
     });
 
@@ -101,7 +101,7 @@ describe("StorageAccessible", () => {
 
       const reader = await ExternalStorageReader.deploy();
       const doRevertCall = reader.interface.encodeFunctionData("doRevert");
-      await expect(instance.callStatic.simulateDelegatecall(reader.address, doRevertCall)).to.be
+      await expect(instance.callStatic.simulate(reader.address, doRevertCall)).to.be
         .reverted;
     });
 


### PR DESCRIPTION
As discussed, renamed methods to be more succinct. 

Related to https://github.com/gnosis/safe-contracts/pull/291