### PR TITLE
Add support for Solidiy 0.7 and 0.8

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,11 +1,1 @@
-# Mnemonic or MNEMONIC
-#MNEMONIC='your mnemonic here'
-#PK='your-private-key'
-
-# Gas Price
-# GAS_PRICE_GWEI=4
-
-# Allow to use native solc docker image
-#   - Requires to have the image:
-#       docker pull ethereum/solc:0.4.25
-SOLC_USE_DOCKER=false
+SOLC_VERSION=0.8.3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,7 @@ jobs:
       matrix:
         node-version: [14.x, 15.x]
         os: [ubuntu-latest]
+        solc: ["0.7.6", "0.8.3"]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v2
@@ -26,4 +27,4 @@ jobs:
           restore-keys: |
             ${{ matrix.os }}-yarn-
       - run: yarn --frozen-lockfile
-      - run: yarn test
+      - run: SOLC_VERSION=${{ matrix.solc }} yarn test

--- a/contracts/EtherToken.sol
+++ b/contracts/EtherToken.sol
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: LGPL-3.0-only
-pragma solidity ^0.7.0;
+pragma solidity >=0.7.0 <0.9.0;
+
 import "./GnosisStandardToken.sol";
 
 /// @title Token contract - Token exchanging Ether 1:1
@@ -36,7 +37,7 @@ contract EtherToken is GnosisStandardToken {
         // Balance covers value
         balances[msg.sender] = balances[msg.sender].sub(value);
         totalTokens = totalTokens.sub(value);
-        msg.sender.transfer(value);
+        payable(msg.sender).transfer(value);
         emit Withdrawal(msg.sender, value);
     }
 }

--- a/contracts/GnosisStandardToken.sol
+++ b/contracts/GnosisStandardToken.sol
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: LGPL-3.0-only
-pragma solidity ^0.7.0;
+pragma solidity >=0.7.0 <0.9.0;
+
 import "./Token.sol";
 import "./Math.sol";
 import "./Proxy.sol";

--- a/contracts/HumanFriendlyToken.sol
+++ b/contracts/HumanFriendlyToken.sol
@@ -2,7 +2,8 @@
 
 /// Implements ERC 20 Token standard including extra accessors for human readability.
 /// See: https://github.com/ethereum/EIPs/blob/master/EIPS/eip-20-token-standard.md
-pragma solidity ^0.7.0;
+pragma solidity >=0.7.0 <0.9.0;
+
 import "./Token.sol";
 
 /// @title Abstract human-friendly token contract - Functions to be implemented by token contracts

--- a/contracts/Math.sol
+++ b/contracts/Math.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: LGPL-3.0-only
-pragma solidity ^0.7.0;
+pragma solidity >=0.7.0 <0.9.0;
 
 /// @title Math library - Allows calculation of logarithmic and exponential functions
 /// @author Alan Lu - <alan.lu@gnosis.pm>

--- a/contracts/Proxy.sol
+++ b/contracts/Proxy.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: LGPL-3.0-only
-pragma solidity ^0.7.0;
+pragma solidity >=0.7.0 <0.9.0;
 
 /// @title Proxied - indicates that a contract will be proxied. Also defines storage requirements for Proxy.
 /// @author Alan Lu - <alan@gnosis.pm>

--- a/contracts/StorageAccessible.sol
+++ b/contracts/StorageAccessible.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: LGPL-3.0-only
-pragma solidity ^0.7.0;
+pragma solidity >=0.7.0 <0.9.0;
 
 /// @title ViewStorageAccessible - Interface on top of StorageAccessible base class to allow simulations from view functions
 interface ViewStorageAccessible {

--- a/contracts/Token.sol
+++ b/contracts/Token.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 /// Implements ERC 20 Token standard: https://github.com/ethereum/EIPs/blob/master/EIPS/eip-20-token-standard.md
-pragma solidity ^0.7.0;
+pragma solidity >=0.7.0 <0.9.0;
 
 /// @title Abstract token contract - Functions to be implemented by token contracts
 abstract contract Token {

--- a/contracts/test/StorageAccessibleWrapper.sol
+++ b/contracts/test/StorageAccessibleWrapper.sol
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: LGPL-3.0-only
-pragma solidity ^0.7.0;
+pragma solidity >=0.7.0 <0.9.0;
+
 import "../StorageAccessible.sol";
 
 contract StorageAccessibleWrapper is StorageAccessible {

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -1,9 +1,14 @@
 import "@nomiclabs/hardhat-waffle";
 
+import dotenv from "dotenv";
+
+dotenv.config();
+const { SOLC_VERSION } = process.env;
+
 export default {
   paths: {
     artifacts: "build/artifacts",
-    cache: "build/cache"
+    cache: "build/cache",
   },
-  solidity: "0.7.6"
+  solidity: SOLC_VERSION ?? "0.8.3",
 };


### PR DESCRIPTION
This PR modified the contract solidity version pragma to simultaneously support both 0.7 and 0.8.

Additionally, CI is updated to run both on both 0.7 and 0.8.