### PR TITLE
Refactor `StorageAccessible.simulate` into library

### DIFF
--- a/contracts/storage/StorageAccessible.sol
+++ b/contracts/storage/StorageAccessible.sol
@@ -2,14 +2,17 @@
 pragma solidity >=0.7.0 <0.9.0;
 
 import "./StorageReadable.sol";
+import "./StorageSimulate.sol";
 import "./StorageSimulation.sol";
 
 /**
- * @title Storage Simulation Library
+ * @title Storage Accessible Extension
  * @author Gnosis Developers
  * @dev Generic base contract that allows callers to access all internal storage.
  */
 abstract contract StorageAccessible is StorageReadable, StorageSimulation {
+    using StorageSimulate for StorageSimulation;
+
     /**
      * @dev Simulates a delegete call to a target contract in the context of self.
      *
@@ -19,64 +22,10 @@ abstract contract StorageAccessible is StorageReadable, StorageSimulation {
      * @param targetContract Address of the contract containing the code to execute.
      * @param calldataPayload Calldata that should be sent to the target contract (encoded method name and arguments).
      */
-    function simulate(
-        address targetContract,
-        bytes calldata calldataPayload
-    ) public returns (bytes memory response) {
-        // Suppress compiler warnings about not using parameters, while allowing
-        // parameters to keep names for documentation purposes. This does not
-        // generate code.
-        targetContract;
-        calldataPayload;
-
-        assembly {
-            let internalCalldata := mload(0x40)
-            // Store `simulateAndRevert.selector`.
-            mstore(internalCalldata, "\xb4\xfa\xba\x09")
-            // Abuse the fact that both this and the internal methods have the
-            // same signature, and differ only in symbol name (and therefore,
-            // selector) and copy calldata directly. This saves us approximately
-            // 250 bytes of code and 300 gas at runtime over the
-            // `abi.encodeWithSelector` builtin.
-            calldatacopy(
-                add(internalCalldata, 0x04),
-                0x04,
-                sub(calldatasize(), 0x04)
-            )
-
-            // `pop` is required here by the compiler, as top level expressions
-            // can't have return values in inline assembly. `call` typically
-            // returns a 0 or 1 value indicated whether or not it reverted, but
-            // since we know it will always revert, we can safely ignore it.
-            pop(call(
-                gas(),
-                address(),
-                0,
-                internalCalldata,
-                calldatasize(),
-                // The `simulateAndRevert` call always reverts, and instead
-                // encodes whether or not it was successful in the return data.
-                // The first 32-byte word of the return data contains the
-                // `success` value, so write it to memory address 0x00 (which is
-                // reserved Solidity scratch space and OK to use).
-                0x00,
-                0x20
-            ))
-
-
-            // Allocate and copy the response bytes, making sure to increment
-            // the free memory pointer accordingly (in case this method is
-            // called as an internal function). The remaining `returndata[0x20:]`
-            // contains the ABI encoded response bytes, so we can just write it
-            // as is to memory.
-            let responseSize := sub(returndatasize(), 0x20)
-            response := mload(0x40)
-            mstore(0x40, add(response, responseSize))
-            returndatacopy(response, 0x20, responseSize)
-
-            if iszero(mload(0x00)) {
-                revert(add(response, 0x20), mload(response))
-            }
-        }
+    function simulate(address targetContract, bytes calldata calldataPayload)
+        external
+        returns (bytes memory response)
+    {
+        response = StorageSimulation(this).simulate(targetContract, calldataPayload);
     }
 }

--- a/contracts/storage/StorageSimulate.sol
+++ b/contracts/storage/StorageSimulate.sol
@@ -1,0 +1,139 @@
+// SPDX-License-Identifier: LGPL-3.0-only
+pragma solidity >=0.7.0 <0.9.0;
+
+import "./StorageSimulation.sol";
+
+/**
+ * @title Storage Simulation Library
+ * @author Gnosis Developers
+ * @dev Convenience methods for interacting with {@link StorageSimulation} contracts.
+ */
+library StorageSimulate {
+    using StorageSimulate for StorageSimulation;
+
+    /**
+     * @dev Precomputed selector of {@link StorageSimulation.simulateAndRevert}.
+     *
+     * This is defined as a constant hex literal so that it can be used in
+     * inline assembly.
+     */
+    bytes4 internal constant SIMULATE_AND_REVERT_SELECTOR = hex"b4faba09";
+
+    /**
+     * @dev Mask for 32-byte padding calldata length.
+     *
+     * This is defined as a constant as negative integer literals are not
+     * permitted in inline assembly.
+     */
+    int256 private constant PAD_MASK = -32;
+
+    /**
+     * @dev Simulate a delegete call in a specified context to a target contract.
+     *
+     * Internally reverts execution to avoid side effects (making it static).
+     * Catches revert and returns encoded result as bytes.
+     *
+     * @param context The context to simulate the delegate call.
+     * @param targetContract Address of the contract containing the code to execute.
+     * @param calldataPayload Calldata that should be sent to the target contract.
+     */
+    function simulate(
+        StorageSimulation context,
+        address targetContract,
+        bytes memory calldataPayload
+    ) internal returns (bytes memory response) {
+        assembly {
+            // Solidity memory bytes should always point to a memory address past
+            // 0x60, but just make sure to avoid consuming all the gas in the call
+            // if this invariant is broken. This is required because we encode the
+            // internal call in place.
+            if lt(calldataPayload, 0x60) {
+                revert(0, 0)
+            }
+
+            // In order to avoid copying the calldata payload, which requires a
+            // loop, encode the internal call in-place by temporarily writing
+            // over the memory preceding the calldata payload and restoring it
+            // after the call. The internall call is encoded as:
+            // `selector:bytes4 || target:address || payload.offset:uint256 || payload:bytes`.
+            let internalCalldata := sub(calldataPayload, 0x44)
+
+            // Backup memory that we will be temporarily overwriting.
+            let temp1 := mload(internalCalldata)
+            let temp2 := mload(add(internalCalldata, 0x04))
+            let temp3 := mload(add(internalCalldata, 0x24))
+
+            // Encode the internal function call.
+            mstore(internalCalldata, SIMULATE_AND_REVERT_SELECTOR)
+            mstore(add(internalCalldata, 0x04), targetContract)
+            mstore(add(internalCalldata, 0x24), 0x40)
+
+            // `pop` is required here by the compiler, as top level expressions
+            // can't have return values in inline assembly. `call` typically
+            // returns a 0 or 1 value indicated whether or not it reverted, but
+            // since we expect it to always revert, we can safely ignore it.
+            pop(
+                call(
+                    gas(),
+                    context,
+                    0,
+                    internalCalldata,
+                    // Solidity ABI requires function data to be 32-byte padded
+                    // (excluding the selector). This means the internal call data
+                    // length will be:
+                    // ```
+                    //    4 // selector
+                    // + 32 // target contract
+                    // + 32 // calldata payload offset
+                    // + 32 // calldata payload length
+                    // +  N // 32-byte padded calldata payload data
+                    // ```
+                    // Since 32 is a power of two, we can implement padding a
+                    // simple masked addition.
+                    add(0x64, and(add(mload(calldataPayload), 31), PAD_MASK)),
+                    // The `simulateAndRevert` call always reverts, and instead
+                    // encodes whether or not it was successful in the return data.
+                    // The first 32-byte word of the return data contains the
+                    // `success` value, so write it to memory address 0x00 (which is
+                    // reserved Solidity scratch space and OK to use).
+                    0x00,
+                    0x20
+                )
+            )
+            let success := mload(0x00)
+
+            // Make sure the call returns at least 64 bytes of data. This is the
+            // smallest possible encoding of `success:bool || response:bytes`.
+            if lt(returndatasize(), 0x40) {
+                revert(0, 0)
+            }
+
+            // Recover the memory that we overwrote.
+            mstore(internalCalldata, temp1)
+            mstore(add(internalCalldata, 0x04), temp2)
+            mstore(add(internalCalldata, 0x24), temp3)
+
+            // Allocate and copy the response bytes, making sure to increment
+            // the free memory pointer accordingly. The remaining `returndata[0x20:]`
+            // contains the ABI encoded response bytes, so we can just write it
+            // as is to memory.
+            let responseSize := sub(returndatasize(), 0x20)
+            response := mload(0x40)
+            mstore(0x40, add(response, responseSize))
+            returndatacopy(response, 0x20, responseSize)
+
+            // Make sure that the response byte length is smaller than its encoded
+            // size. This protects us from calling into a contract that doesn't
+            // implement `StorageSimulation` returning unexpected data and causing
+            // `response` to reference bytes beyond our allocation.
+            if gt(mload(response), responseSize) {
+                revert(0, 0)
+            }
+
+            // Finally propagate the delegate call's revert.
+            if iszero(success) {
+                revert(add(response, 0x20), mload(response))
+            }
+        }
+    }
+}

--- a/contracts/storage/StorageSimulate.sol
+++ b/contracts/storage/StorageSimulate.sol
@@ -9,8 +9,6 @@ import "./StorageSimulation.sol";
  * @dev Convenience methods for interacting with {@link StorageSimulation} contracts.
  */
 library StorageSimulate {
-    using StorageSimulate for StorageSimulation;
-
     /**
      * @dev Precomputed selector of {@link StorageSimulation.simulateAndRevert}.
      *
@@ -126,7 +124,7 @@ library StorageSimulate {
             // size. This protects us from calling into a contract that doesn't
             // implement `StorageSimulation` returning unexpected data and causing
             // `response` to reference bytes beyond our allocation.
-            if gt(mload(response), responseSize) {
+            if gt(mload(response), sub(responseSize, 0x20)) {
                 revert(0, 0)
             }
 

--- a/contracts/storage/ViewStorageAccessible.sol
+++ b/contracts/storage/ViewStorageAccessible.sol
@@ -1,12 +1,11 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 pragma solidity >=0.7.0 <0.9.0;
 
-import "./StorageAccessible.sol";
-
 /**
- * @title ViewStorageAccessible
+ * @title View Storage Accessible Interface
  * @author Gnosis Developers
- * @dev Interface on top of StorageAccessible base class to allow simulations from view functions
+ * @dev Interface on top of {@link StorageAccessible} base class to allow
+ * simulations from view functions
  */
 interface ViewStorageAccessible {
     /**

--- a/test/storage/StorageAccessible.spec.ts
+++ b/test/storage/StorageAccessible.spec.ts
@@ -49,7 +49,9 @@ describe("StorageAccessible", () => {
 
       const reader = await ExternalStorageReader.deploy();
       const doRevertCall = reader.interface.encodeFunctionData("doRevert");
-      await expect(instance.callStatic.simulate(reader.address, doRevertCall)).to.be.reverted;
+      await expect(instance.callStatic.simulate(reader.address, doRevertCall)).to.be.revertedWith(
+        "test revert",
+      );
     });
 
     it("allows detection of reverts when invoked from other smart contract", async () => {

--- a/test/storage/StorageSimulate.spec.ts
+++ b/test/storage/StorageSimulate.spec.ts
@@ -1,0 +1,144 @@
+import { expect } from "chai";
+import { BytesLike, Contract, ContractFactory } from "ethers";
+import { ethers } from "hardhat";
+
+describe("StorageSimulate", () => {
+  let StorageSimulateWrapper: ContractFactory;
+
+  // It would be awesome to use the `ethereum-waffle` mock contract here, but
+  // unfortunately, it doesn't support reverting with arbitrary bytes, only with
+  // revert messages.
+  let MockStorageSimulation: ContractFactory;
+
+  before(async () => {
+    StorageSimulateWrapper = await ethers.getContractFactory("StorageSimulateWrapper");
+    MockStorageSimulation = await ethers.getContractFactory("MockStorageSimulation");
+  });
+
+  enum MockKind {
+    Return = 1,
+    Revert = 2,
+  }
+
+  async function mockSimulateAndRevert(
+    mockContract: Contract,
+    options: {
+      kind?: MockKind;
+      targetContract: string;
+      calldataPayload: BytesLike;
+      response: BytesLike;
+    },
+  ): Promise<void> {
+    const { kind, targetContract, calldataPayload, response } = {
+      kind: MockKind.Revert,
+      ...options,
+    };
+
+    const input = MockStorageSimulation.interface.encodeFunctionData("simulateAndRevert", [
+      targetContract,
+      calldataPayload,
+    ]);
+    await mockContract.mockCall(kind, input, response);
+  }
+
+  function encodeResponse(success: boolean, data: BytesLike): string {
+    return ethers.utils.hexConcat([
+      ethers.utils.defaultAbiCoder.encode(
+        ["bool", "uint256"],
+        [success, ethers.utils.hexDataLength(data)],
+      ),
+      data,
+    ]);
+  }
+
+  function encodeRevert(message: string): string {
+    const iface = new ethers.utils.Interface(["function Error(string)"]);
+    return encodeResponse(false, iface.encodeFunctionData("Error", [message]));
+  }
+
+  describe("simulate", async () => {
+    it("reverts when passed in payload pointing to before the zero slot", async () => {
+      const instance = await StorageSimulateWrapper.deploy();
+      await expect(instance.simulateInvalidMemory()).to.be.reverted;
+    });
+
+    it("pads calldata payload to 32 bytes", async () => {
+      const instance = await StorageSimulateWrapper.deploy();
+      const mock = await MockStorageSimulation.deploy();
+
+      const targetContract = `0x${"2a".repeat(20)}`;
+      for (const length of [0, 10, 28, 32, 42]) {
+        const calldataPayload = [...Array(length)].map((_, i) => i);
+        await mockSimulateAndRevert(mock, {
+          targetContract,
+          calldataPayload,
+          response: encodeResponse(true, "0xbeefc0de"),
+        });
+
+        expect(
+          await instance.callStatic.simulate(mock.address, targetContract, calldataPayload),
+        ).to.equal("0xbeefc0de");
+      }
+    });
+
+    it("silently accepts non-reveted `simulateAndRevert` calls", async () => {
+      const instance = await StorageSimulateWrapper.deploy();
+      const mock = await MockStorageSimulation.deploy();
+
+      await mockSimulateAndRevert(mock, {
+        kind: MockKind.Return,
+        targetContract: ethers.constants.AddressZero,
+        calldataPayload: "0x",
+        response: encodeResponse(true, "0x"),
+      });
+
+      await expect(instance.callStatic.simulate(mock.address, ethers.constants.AddressZero, "0x"))
+        .to.not.be.reverted;
+    });
+
+    it("reverts when simulation response is malformed", async () => {
+      const instance = await StorageSimulateWrapper.deploy();
+      const mock = await MockStorageSimulation.deploy();
+
+      await mockSimulateAndRevert(mock, {
+        kind: MockKind.Return,
+        targetContract: ethers.constants.AddressZero,
+        calldataPayload: "0x",
+        response: "0xbaadc0de",
+      });
+
+      await expect(instance.callStatic.simulate(mock.address, ethers.constants.AddressZero, "0x"))
+        .to.be.reverted;
+    });
+
+    it("reverts when response data length is larger than return size", async () => {
+      const instance = await StorageSimulateWrapper.deploy();
+      const mock = await MockStorageSimulation.deploy();
+
+      await mockSimulateAndRevert(mock, {
+        kind: MockKind.Return,
+        targetContract: ethers.constants.AddressZero,
+        calldataPayload: "0x",
+        response: ethers.utils.defaultAbiCoder.encode(["bool", "uint256"], [true, 1_000_000]),
+      });
+
+      await expect(instance.callStatic.simulate(mock.address, ethers.constants.AddressZero, "0x"))
+        .to.be.reverted;
+    });
+
+    it("propagates internal delegate call reverts", async () => {
+      const instance = await StorageSimulateWrapper.deploy();
+      const mock = await MockStorageSimulation.deploy();
+
+      await mockSimulateAndRevert(mock, {
+        targetContract: ethers.constants.AddressZero,
+        calldataPayload: "0x",
+        response: encodeRevert("test error"),
+      });
+
+      await expect(
+        instance.callStatic.simulate(mock.address, ethers.constants.AddressZero, "0x"),
+      ).to.be.revertedWith("test error");
+    });
+  });
+});

--- a/test/storage/StorageSimulate.spec.ts
+++ b/test/storage/StorageSimulate.spec.ts
@@ -67,7 +67,7 @@ describe("StorageSimulate", () => {
       const mock = await MockStorageSimulation.deploy();
 
       const targetContract = `0x${"2a".repeat(20)}`;
-      for (const length of [0, 10, 28, 32, 42]) {
+      for (const length of [0, 1, 10, 28, 32, 42]) {
         const calldataPayload = [...Array(length)].map((_, i) => i);
         await mockSimulateAndRevert(mock, {
           targetContract,
@@ -119,7 +119,7 @@ describe("StorageSimulate", () => {
         kind: MockKind.Return,
         targetContract: ethers.constants.AddressZero,
         calldataPayload: "0x",
-        response: ethers.utils.defaultAbiCoder.encode(["bool", "uint256"], [true, 1_000_000]),
+        response: ethers.utils.defaultAbiCoder.encode(["bool", "uint256"], [true, 1]),
       });
 
       await expect(instance.callStatic.simulate(mock.address, ethers.constants.AddressZero, "0x"))


### PR DESCRIPTION
This PR refactors the `StorageAccessible.simulate` function into a library. This allows more optimized calling of delegate call simulations. For example, when an external contract would call `StorageAccessible.simulate`, the call graph would look like:

```
TX SomeContract.someMethod
  -> CALL StorageAccessible.simulate
    -> CALL StorageSimulation.simulateAndRervert
      -> DELEGATECALL SomeReader.someViewMethod
```
Now, when using the library, this removes one call and becomes:

```
TX SomeContract.someMethod
  -> CALL StorageSimulation.simulateAndRervert
    -> DELEGATECALL SomeReader.someViewMethod
```

Additionally, a couple of issues were discovered with the original assembly implementation:
- It was :warning: **incorrectly** marked as public. This was an issue since it was abusing the fact that the `msg.data` was already encoded in the way it was expected, which is not true of internal calls
- It did not sufficiently protect against calling contracts that _may not actually implement_ `StorageSimulation` which could cause memory corruption. This wasn't a problem for before, since it was calling with `this`, which was known to handle the `simulateAndRevert` in the expected way, but would become a problem when moved to a library.

In terms of code bloat, this adds around 400 bytes of code to `StorageAccessible` (`StorageSimulation` remains unchanged though :tada:).

### Test Plan

Added unit tests to cover all paths.